### PR TITLE
allow proxy to be run with enabled SELinux

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -24,4 +24,4 @@ then
     MYOPTS="$MYOPTS --net=host"
 fi
 
-docker run $MYOPTS -e PLATFORM -e PORT -e LOCAL_API -e SPANDX_HOST -e SPANDX_PORT --rm -ti --name insightsproxy -p ${SPANDX_PORT:-1337}:${SPANDX_PORT:-1337} $CONTAINER_URL
+docker run $MYOPTS -e PLATFORM -e PORT -e LOCAL_API -e SPANDX_HOST -e SPANDX_PORT --security-opt label=disable --rm -ti --name insightsproxy -p ${SPANDX_PORT:-1337}:${SPANDX_PORT:-1337} $CONTAINER_URL


### PR DESCRIPTION
fixes SELinux labeling so proxy can be run without disabling SELinux