### PR TITLE
Return entitlements info with x-rh-identity

### DIFF
--- a/spandx.config.js
+++ b/spandx.config.js
@@ -38,6 +38,20 @@ const buildUser = input => {
             internal: {
                 org_id: input.account_id
             }
+        },
+        entitlements: {
+            insights: {
+                is_entitled: true
+            },
+            openshift: {
+                is_entitled: true
+            },
+            smart_management: {
+                is_entitled: true
+            },
+            hybrid_cloud: {
+                is_entitled: true
+            }
         }
     };
 


### PR DESCRIPTION
This allows us to test our entitlements checks locally.

The following should be in the Readme IMO:

To test:

```sh
docker build . -t docker.io/redhatinsights/insights-proxy
SPANDX_CONFIG=<your config> ./scripts/run.sh
```

To update the image for everyone:

```sh
docker push docker.io/redhatinsights/insights-proxy
```