### PR TITLE
Changes run to use python3 instead of python2

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,7 +10,7 @@ fi
 # -v is not working well on bash 3.2 on osx
 if [[ -n "$SPANDX_CONFIG" ]]
 then
-    REALPATH=`python2 -c 'import os,sys;print os.path.realpath(sys.argv[1])' $SPANDX_CONFIG`
+    REALPATH=`python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' $SPANDX_CONFIG`
 
     if [[ ! -f $REALPATH ]]
     then


### PR DESCRIPTION
Python2 is going away and hard coding it to python2 breaks on systems without it.