### PR TITLE
Allow RUNNER=podman env var to override default of docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Note to macOS and Windows users using [Docker Machine](https://docs.docker.com/m
 VBoxManage modifyvm "default" --natpf1 "insights,tcp,,1337,,1337"
 ```
 
+### Docker vs Podman
+
+Due to previous issues with podman, the current default is docker.  Can pass `RUNNER=podman` or `RUNNER=docker` environment variable to override.
+
 ### Docker Version
 
 The insights-proxy container utilizes several rewrite rules; including one for `host.docker.internal` which will resolve to the internal IP address used by the host. This special DNS name is stable from version *18.03* for Linux & macOS, however for previous versions the DNS name varied for macOS, see [Stack Overflow](https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container/43541732#43541732). If you are using a version of Docker older than *18.03* on macOS, you will need to either upgrade your Docker version or update you spandx.config.js to map to the appropriate DNS name for your version.

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 set -a
 
-RUNNER=docker
-if ! type $RUNNER >/dev/null 2>&1
-then
-    # disabling podman... damn thing keeps not cleaning up after itself
-    # echo "Using docker, eww you should install podman"
-    RUNNER=docker
-fi
+# Respect RUNNER env var if set.
+# Defaulting to docker - podman keeps not cleaning up after itself.
+RUNNER=${RUNNER:-docker}
 
 CONTAINER_URL=${CONTAINER_URL:-docker.io/redhatinsights/insights-proxy}
 case "`uname -s`" in


### PR DESCRIPTION
Auto-preference for podman was added in a95e23cb6dc658a5ddb39cabe8d9695c5ea5ac9d but cancelled in a4cedc88398284ef9ef7a9078d3d60af0bb3aec6.

I don't know details and whether podman is can be recommended as default (or even fallback for users that don't have docker)...  All I can say it works fine for me (Fedora 30).  :man_shrugging: 
=> This doesn't check which you have, keeps current default, only allows manual override.

@iphands what do you think?
