### PR TITLE
Run container without tty, improve signal propogation

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -42,6 +42,7 @@ do
     conditional_add_param $var
 done
 
+set -x
 $RUNNER run $MYOPTS \
         --rm \
         -ti \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -43,7 +43,7 @@ do
 done
 
 set -x
-$RUNNER run $MYOPTS \
+exec $RUNNER run $MYOPTS \
         --rm \
         -ti \
         --name insightsproxy \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -45,7 +45,6 @@ done
 set -x
 exec $RUNNER run $MYOPTS \
         --rm \
-        -ti \
         --name insightsproxy \
         --security-opt label=disable \
         -p ${SPANDX_PORT:-1337}:${SPANDX_PORT:-1337} \


### PR DESCRIPTION
Hi.  This is not perfect but I spent too much time testing combinations and had to write it down somewhere :-)

## Motivation
I'm trying to launch this proxy together with our app server + more stuff + selenium tests under a runner, specifically https://github.com/kimmobrunfeldt/concurrently.  Both for interactive use and on CI [internal [jira card](https://issues.redhat.com/browse/SDA-2017)].  This created a couple challenges:

- The runner does not provide a pseudo-terminal (and at most connects stdin to one subprocess, which is going to be tests, not this proxy).
  With the `-t` (`--tty`) flag currently passed, docker/podman immediately fails:
  ```sh
  $ scripts/run.sh <&-
  the input device is not a TTY
  ```

- I started seeing situations where the proxy container "detaches" but keeps running.  

  When the runner exits, it kills its remaining children.  Well, actually `concurrently` uses `tree-kill` npm lib to send SIGINT, then SIGTERM, then SIGHUP to _whole subprocess tree_; I suspect result may depend on order (?)

  I think Jenkins will also kill timing out jobs with SIGTERM, but haven't gotten there yet :)

## What I want from run.sh

Don't require a tty.

User shouldn't care this is implemented as a container.  Sending SIGTERM and SIGINT to run.sh itself should terminate the proxy.  (Ctrl+C too of course, but that already works.)

Detaching is the worst! :no_good_man:  run.sh appears to exit, but proxy is still up, and next run.sh fails (The container name "/insightsproxy" is already in use).

Remember that Ctrl+C sends signal to _all_ processes in the "foreground process group associated with the terminal" (see [glibc docs](https://www.gnu.org/software/libc/manual/html_node/Job-Control.html) for the gory details :neckbeard:).  
In contrast, I'm using `pkill` for testing below, which here simulates the runner sending a signal only to `run.sh`.

## Investigation results

The proxy is not really interactive, so initially, I wanted to drop `-ti` (`--tty --interactive`) and deal with signals separately, but saw some rumors tty improves docker signal propogation.  So, homework time :grin: :memo:...  

Other factors found by googling: `--sig-proxy` (already defaults true) and `--init`, details below.

The good news is these rumors were outdated!

| how run                | <kbd>Ctrl+C</kbd> | pkill -INT -f "$RUNNER run" | pkill -INT 'run.sh' | pkill -TERM -f "$RUNNER run" | pkill -TERM 'run.sh' |
|------------------------|-------------------|-----------------------------|---------------------|------------------------------|----------------------|
| docker --tty -i        | exits             | detaches¹                   | nothing             | detaches¹, mangled terminal  | detaches²            |
| podman --tty -i        | exits             | detaches¹                   | nothing             | nothing                      | detaches²            |
| docker no stdin        | exits             | exits                       | nothing             | nothing                      | detaches²            |
| podman no stdin        | exits             | exits                       | nothing             | nothing                      | detaches²            |
| docker --init --tty -i | exits             | detaches¹                   | nothing             | detaches¹, mangled terminal  | detaches²            |
| podman --init --tty -i | exits             | detaches¹                   | nothing             | exits                        | detaches²            |
| docker --init no stdin | exits             | exits                       | nothing             | exits                        | detaches²            |
| podman --init no stdin | exits             | exits                       | nothing             | exits                        | detaches²            |

<details>

<summary>Legend and details how I tested</summary>

"no stdin" = without `--tty`, without `--interactive`, with stdin closed `run.sh <&-`.  
detaches¹ = `run.sh` exits, `$RUNNER run` exits, container detached from  stdin/out but still runs.  
detaches² = `run.sh` exits, `$RUNNER run` still runs reparented under systemd.  Container detached from stdin/out, can `$RUNNER attach` in same way, so distinction doesn't matter AFAICT.  
mangled terminal = misplaced bash prompt, bash editing broken, `reset` helps.  fish is apparently immune.

Fedora 30, moby-engine-18.06.3-2.ce.gitd7080c1.fc30.x86_64, podman-1.7.0-3.fc30.x86_64.

`podman --init` not packaged right for Fedora yet, I cheated by compiling catatonit myself.

- Even after detaching, `docker`/`podman attach insightsproxy` then <kbd>Ctrl+C</kbd> works. Github issues said sometimes Ctrl+C doesn't work same after `attach` as initially, but I haven't seen that here :relieved:.

Command I used to diagnose state (here 26384 was the pid of the bash from which I was starting run.sh; the `""` pairs are a kludge to prevent pgrep/pkill from matching the watch command):
```sh
watch --color 'docker ps; podman ps; echo; pstree -ha --show-parents $(pgrep "run"".sh" || pgrep -f "doc""ker run" || pgrep -f "pod""man run" || echo 26384)'
```
Tip: can use `MYOPTS` env var to pass docker/podman options without editing run.sh.

</details>

## => What's in this PR

We have a perfect winner combination :tada:, but can't fully apply it :neutral_face: 

### 0. Debug — made run.sh print the actual docker/podman command.

### 1. Clear win: Get rid of intermediate run.sh process

Using `exec` to make `$RUNNER run` a direct child of whoever called run.sh.

### 2. Win: drop --tty --interactive

This allows run.sh to run without a tty — even with stdin closed! — and _improves_ signal delivery a bit.

- Tiny consequence: with a tty, it was possible to deliberately detach by pressing <kbd>Ctrl+P Ctrl+Q</kbd> sequence, now won't work.  You can still `MYOPTS='--detach' scripts/run.sh` ahead of time; `kill -9` the docker run process also seems to work.

### 3. Deferred: --init

The final win is from `docker run --init`.  To steal [a good explaination](https://github.com/Yelp/dumb-init):

> When processes are sent a signal on a normal Linux system, the kernel will first check for any custom handlers the process has registered for that signal, and otherwise fall back to default behavior (for example, killing the process on SIGTERM).
>
> However, if the process receiving the signal is PID 1, it gets special treatment by the kernel; if it hasn't registered a handler for the signal, the kernel won't fall back to default behavior, and nothing happens. In other words, if your process doesn't explicitly handle these signals, sending it SIGTERM will have no effect at all.

`--init` injects a simple PID 1 process, forwarding signals to the proxy which is now a regular PID, so exits by default on SIGINT / SIGTERM :heavy_check_mark:

Except that `podman run --init` is not portable, the init it injects is missing in Fedora and some other distros: https://github.com/containers/libpod/issues/4159 :crying_cat_face:  
In above tests I cheated by compiling it myself to know whether it _can_ work.

=> So omitting from this PR.  I can make only `docker` use it if you want?  

Personally I'm actually interested in podman.  The portable solution would be to tweak the spandx image to add some "init" process, or spandx code to register non-default signal handlers that exit...