### PR TITLE
Run dumb-init as container PID1 to improve signal propogation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:29
 
 RUN dnf update -y && \
-        dnf install -y nodejs && \
+        dnf install -y dumb-init nodejs && \
         dnf clean all
 
 COPY ./package.json /package.json
@@ -12,4 +12,5 @@ COPY ./ssl /ssl
 
 COPY ./spandx.config.js /spandx.config.js
 
-CMD [ "/usr/bin/node", "/node_modules/spandx/app/cli.js" ]
+# dumb-init being PID1 allows SIGTERM etc. to reach the node process.
+CMD [ "/usr/bin/dumb-init", "/usr/bin/node", "/node_modules/spandx/app/cli.js" ]


### PR DESCRIPTION
The kernel special-cases PID 1 shielding it from signals, except those it defined explicit handlers for.  The result was that SIGTERM, SIGHUP and various others just "detached" docker run but didn't stop the proxy.  (see also #32 for tests)

There are several minimal "container init systems" that solve this (plus they reap zombies, but I don't think spandx spawns processes?).
`docker run --init` and `podman run --init` inject one without modifying the Dockerfile, but podman's is not well packaged yet, so adding here is better.
Picked https://github.com/Yelp/dumb-init because it's packaged on Fedora.