### PR TITLE
Use fedora 33,  set large --max-http-header-size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:29
+FROM fedora:33
 
 RUN dnf update -y && \
         dnf install -y dumb-init nodejs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY ./ssl /ssl
 COPY ./spandx.config.js /spandx.config.js
 
 # dumb-init being PID1 allows SIGTERM etc. to reach the node process.
-CMD [ "/usr/bin/dumb-init", "/usr/bin/node", "/node_modules/spandx/app/cli.js" ]
+CMD [ "/usr/bin/dumb-init", "/usr/bin/node", "--max-http-header-size=65536", "/node_modules/spandx/app/cli.js" ]


### PR DESCRIPTION
Closes #38.

- [x] raised limit so unlikely to happen.
- [x] if happens, returns clearer "431 Request Header Fields Too Large" instead of "400 Bad Request".
- [ ] if happens, log still doesn't show anything.  I think that's OK given the clear http code.