### PR TITLE
bump node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:29
+FROM quay.io/fedora/fedora:33-x86_64
 
 RUN dnf update -y && \
         dnf install -y dumb-init nodejs && \

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "insights-proxy",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Proxy for local Insights development",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When trying to run the old one i get. The old Fedora image was on Node 11, this should bump it to a more recent one. (and switching it to quay)

```
Error: yargs supports a minimum Node.js version of 12. Read our version support policy: https://github.com/yargs/yargs#supported-nodejs-versions
    at Object.<anonymous> (/node_modules/yargs/build/index.cjs:1:55294)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/node_modules/yargs/index.cjs:5:30)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
```